### PR TITLE
6.0 upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target/
+project/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 project/
+.DS_Store

--- a/source/build.sbt
+++ b/source/build.sbt
@@ -1,0 +1,20 @@
+enablePlugins(org.nlogo.build.NetLogoExtension)
+
+name := "matlab"
+
+netLogoClassManager := "matlabExtension"
+
+netLogoZipSources   := false
+
+javaSource in Compile := baseDirectory.value / "src"
+
+javacOptions ++= Seq("-g", "-deprecation", "-Xlint:all", "-Xlint:-serial", "-Xlint:-path",
+  "-encoding", "us-ascii")
+
+// The remainder of this file is for options specific to bundled netlogo extensions
+// if copying this extension to build your own, it may be best to delete
+// everything below line 14
+netLogoTarget :=
+  org.nlogo.build.NetLogoExtension.directoryTarget(baseDirectory.value)
+
+netLogoVersion := "6.0.2-M1"

--- a/source/project/build.properties
+++ b/source/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.16

--- a/source/project/plugins.sbt
+++ b/source/project/plugins.sbt
@@ -1,0 +1,6 @@
+resolvers += Resolver.url(
+  "NetLogo-JVM",
+  url("http://dl.bintray.com/content/netlogo/NetLogo-JVM"))(
+    Resolver.ivyStylePatterns)
+
+addSbtPlugin("org.nlogo" % "netlogo-extension-plugin" % "3.0")

--- a/source/src/matlabConnectionHolder.java
+++ b/source/src/matlabConnectionHolder.java
@@ -88,7 +88,8 @@ public class matlabConnectionHolder
 			 }
 			 else 
 			 {
-				 final String dosCommand = "matlab -nosplash -r matlabServer1(" + PORT + ")";
+				 //final String dosCommand = "matlab -nosplash -r matlabServer1(" + PORT + ")";
+				 final String[] dosCommand = {"/Applications/MATLAB_R2017a.app/bin/matlab", "-desktop", "-r 'matlabServer1(" + PORT + ")'"};
 				 matlabProc = Runtime.getRuntime().exec(dosCommand);
 			     return true;
 			 }
@@ -113,7 +114,8 @@ public class matlabConnectionHolder
 			 }
 			 else 
 			 {
-				 final String dosCommand = "matlab -automate -r matlabServer";
+				 //final String dosCommand = "matlab -automate -r matlabServer";
+				 final String[] dosCommand = {"/Applications/MATLAB_R2017a.app/bin/matlab", "-desktop", "-r matlabServer1"};
 				 matlabProc = Runtime.getRuntime().exec(dosCommand);
 			     return true;
 			 }

--- a/source/src/matlabConnectionHolder.java
+++ b/source/src/matlabConnectionHolder.java
@@ -82,14 +82,17 @@ public class matlabConnectionHolder
 		  {
 			 if (isWindows())
 			 {
-				 final String dosCommand = "cmd /c matlab -nosplash -r matlabServer1(" + PORT + ")";
+				 final String[] dosCommand = {"cmd", "/c", "matlab", "-desktop", "-r", "matlabServer1(" + PORT + ")"};
 				 matlabProc = Runtime.getRuntime().exec(dosCommand);
 			     return true;
 			 }
 			 else 
 			 {
-				 //final String dosCommand = "matlab -nosplash -r matlabServer1(" + PORT + ")";
-				 final String[] dosCommand = {"/Applications/MATLAB_R2017a.app/bin/matlab", "-desktop", "-r 'matlabServer1(" + PORT + ")'"};
+				 // MatLab needs to be on the path used for this to work. 
+				 // On macOS Sierra 10.12 and later this can be configured with 
+				 // the command line command below:
+				 // sudo launchctl config user path $PATH:/<path to matlab>/bin
+				 final String[] dosCommand = {"matlab", "-desktop", "-r 'matlabServer1(" + PORT + ")'"};
 				 matlabProc = Runtime.getRuntime().exec(dosCommand);
 			     return true;
 			 }
@@ -108,14 +111,17 @@ public class matlabConnectionHolder
 		  {
 			 if (isWindows())
 			 {
-				 final String dosCommand = "cmd /c matlab -automate -r matlabServer";
+				 final String[] dosCommand = {"cmd", "/c", "matlab", "-desktop", "-r", "matlabServer1"};
 				 matlabProc = Runtime.getRuntime().exec(dosCommand);
 			     return true;
 			 }
 			 else 
 			 {
-				 //final String dosCommand = "matlab -automate -r matlabServer";
-				 final String[] dosCommand = {"/Applications/MATLAB_R2017a.app/bin/matlab", "-desktop", "-r matlabServer1"};
+				 // MatLab needs to be on the path used for this to work. 
+				 // On macOS Sierra 10.12 and later this can be configured with 
+				 // the command line command below:
+				 // sudo launchctl config user path $PATH:/<path to matlab>/bin
+				 final String[] dosCommand = {"matlab", "-desktop", "-r matlabServer1"};
 				 matlabProc = Runtime.getRuntime().exec(dosCommand);
 			     return true;
 			 }

--- a/source/src/matlabExtension.java
+++ b/source/src/matlabExtension.java
@@ -1,4 +1,7 @@
 import org.nlogo.api.*;
+import org.nlogo.core.Syntax;
+import org.nlogo.core.SyntaxJ;
+import org.nlogo.core.LogoList;
 
 public class matlabExtension extends DefaultClassManager 
 {
@@ -26,11 +29,11 @@ public class matlabExtension extends DefaultClassManager
 	  /*
 	   * Send any MatLab command as a string to be evaluated
 	   */
-	  public static class matlabEval extends DefaultCommand
+	  public static class matlabEval implements Command
 	  {	 
 		  public Syntax getSyntax() 
 		  {
-			    return Syntax.commandSyntax(new int[] {Syntax.StringType()});
+			    return SyntaxJ.commandSyntax(new int[] {Syntax.StringType()});
 		  }
 		  
 	  	  public void perform(Argument args[], Context context)
@@ -61,11 +64,11 @@ public class matlabExtension extends DefaultClassManager
 	  /*
 	   * Send a string to be stored as a variable in MatLab
 	   */
-	  public static class matlabSendString extends DefaultCommand
+	  public static class matlabSendString implements Command
 	  {	 
 		  public Syntax getSyntax() 
 		  {
-			    return Syntax.commandSyntax(new int[] {Syntax.StringType(), Syntax.StringType()});
+			    return SyntaxJ.commandSyntax(new int[] {Syntax.StringType(), Syntax.StringType()});
 		  }
 		  
 	  	  public void perform(Argument args[], Context context)
@@ -97,11 +100,11 @@ public class matlabExtension extends DefaultClassManager
 	  /*
 	   * Send a string list to be stored as a variable in MatLab
 	   */
-	  public static class matlabSendStringList extends DefaultCommand
+	  public static class matlabSendStringList implements Command
 	  {	 
 		  public Syntax getSyntax() 
 		  {
-			    return Syntax.commandSyntax(new int[] {Syntax.StringType(), Syntax.ListType()});
+			    return SyntaxJ.commandSyntax(new int[] {Syntax.StringType(), Syntax.ListType()});
 		  }
 		  
 	  	  public void perform(Argument args[], Context context)
@@ -139,11 +142,11 @@ public class matlabExtension extends DefaultClassManager
 	  /*
 	   * Send a double to be stored as a variable in the Matlab environment
 	   */
-	  public static class matlabSendDouble extends DefaultCommand
+	  public static class matlabSendDouble implements Command
 	  {	 
 		  public Syntax getSyntax() 
 		  {
-			    return Syntax.commandSyntax(new int[] {Syntax.StringType(), Syntax.NumberType()});
+			    return SyntaxJ.commandSyntax(new int[] {Syntax.StringType(), Syntax.NumberType()});
 		  }
 		  
 	  	  public void perform(Argument args[], Context context)
@@ -176,11 +179,11 @@ public class matlabExtension extends DefaultClassManager
 	  /*
 	   * Send a list of numbers to be stored as an nx1 vector in Matlab
 	   */
-	  public static class matlabSendDoubleList extends DefaultCommand
+	  public static class matlabSendDoubleList implements Command
 	  {	 
 		  public Syntax getSyntax() 
 		  {
-			    return Syntax.commandSyntax(new int[] {Syntax.StringType(), Syntax.ListType()});
+			    return SyntaxJ.commandSyntax(new int[] {Syntax.StringType(), Syntax.ListType()});
 		  }
 		  
 	  	  public void perform(Argument args[], Context context)
@@ -218,11 +221,11 @@ public class matlabExtension extends DefaultClassManager
 	  /*
 	   * Returns a string stored in the Matlab environment (if it exists)
 	   */
-	  public static class matlabGetString extends DefaultReporter
+	  public static class matlabGetString implements Reporter
 	  {	 
 		  public Syntax getSyntax() 
 		  {
-			    return Syntax.reporterSyntax(new int[] {Syntax.StringType()}, Syntax.StringType());
+			    return SyntaxJ.reporterSyntax(new int[] {Syntax.StringType()}, Syntax.StringType());
 		  }
 		  
 	  	  public Object report(Argument args[], Context context)
@@ -252,11 +255,11 @@ public class matlabExtension extends DefaultClassManager
 	  /*
 	   * Returns a string list stored in the Matlab environment (if it exists)
 	   */
-	  public static class matlabGetStringList extends DefaultReporter
+	  public static class matlabGetStringList implements Reporter
 	  {	 
 		  public Syntax getSyntax() 
 		  {
-			    return Syntax.reporterSyntax(new int[] {Syntax.StringType()}, Syntax.ListType());
+			    return SyntaxJ.reporterSyntax(new int[] {Syntax.StringType()}, Syntax.ListType());
 		  }
 		  
 	  	  public Object report(Argument args[], Context context)
@@ -293,11 +296,11 @@ public class matlabExtension extends DefaultClassManager
 	  /*
 	   * Returns a double that has been stored in the Matlab environment (if it exists)	  
 	   */
-	  public static class matlabGetDouble extends DefaultReporter
+	  public static class matlabGetDouble implements Reporter
 	  {	 
 		  public Syntax getSyntax() 
 		  {
-			    return Syntax.reporterSyntax(new int[] {Syntax.StringType()}, Syntax.NumberType());
+			    return SyntaxJ.reporterSyntax(new int[] {Syntax.StringType()}, Syntax.NumberType());
 		  }
 		  
 		  public Object report(Argument args[], Context context)
@@ -328,11 +331,11 @@ public class matlabExtension extends DefaultClassManager
 	  /*
 	   * Returns a double[] (as a LogoList) that is stored in the Matlab environment (if it exists)
 	   */
-	  public static class matlabGetDoubleList extends DefaultReporter
+	  public static class matlabGetDoubleList implements Reporter
 	  {	 
 		  public Syntax getSyntax() 
 		  {
-			    return Syntax.reporterSyntax(new int[] {Syntax.StringType()}, Syntax.ListType());
+			    return SyntaxJ.reporterSyntax(new int[] {Syntax.StringType()}, Syntax.ListType());
 		  }
 		  
 		  public Object report(Argument args[], Context context)


### PR DESCRIPTION
In this pull request, we've updated the Java source so that it can build and run with NetLogo 6.0.2. We've also tweaked the MATLAB startup commands so they use the `String[]` [form of `Runtime.exec`](https://docs.oracle.com/javase/8/docs/api/java/lang/Runtime.html#exec-java.lang.String:A-). We tested the tweaked startup commands on both Windows 10 (MATLAB R2017A) and Mac OS Sierra (using a 2017 version of MATLAB).

The source here compiles without error against the netlogo 6.0.2 jar and Java 8. Using sbt, this jar is pulled in automatically. As configured here, running `sbt package` from the "source" directory will build the jar and place it in the "source" directory.

A few questions that can help finalize this pull request:

* Do you want to upgrade your build (I'm guessing you're building using an IDE) to build this instead of using `sbt`? If so, would you like the sbt project files removed? (The NetLogo 6 jar can be obtained [here](https://dl.bintray.com/netlogo/NetLogo-JVM/org/nlogo/netlogo/6.0.2/netlogo-6.0.2.jar) from bintray)
* Do you want to stay with `sbt`? If so, would you like me to add an `sbt` launcher script to this project which will automatically install sbt for a user when run?
* Are there any other tweaks or changes you would like to see made to this pull request before it can be merged?

Thanks!